### PR TITLE
Fix github action workflow to no longer publish empty npm package

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -24,10 +24,9 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       run: |
-        npm i
+        npm ci
         npm run lint
         npm run test
-        npm run build --if-present
 
   publish:
     needs: [build]
@@ -39,6 +38,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - name: npm build
+        run: |
+          npm ci
+          npm run build --if-present
       - name: Publish
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: mikeal/merge-release@master


### PR DESCRIPTION
The `btcmarkets-node-sdk` package being built by GitHub actions is an empty package that does not contain any code. This can be verified by inspecting the contents manually or using the output of `btcmarkets-node-sdk`:

```
$ npx list-npm-contents btcmarkets-node-sdk
package.json
README.md
```

The `build-publish.yml` workflow specifies two jobs (`build` and `publish`), however the `publish` step does not contain steps to build the package. In GitHub Actions, there is no shared state between jobs (even with a dependency specified), so the compilation performed in the `build` job is not available for the `npm publish` step.

This PR updates the `publish` build job to perform an `npm ci` followed by a `npm build` so that the `dist/` folder exists for the `npm publish` step.

Additionally I have replaced `npm i` calls with `npm ci` as this is recommended for automated build environments to ensure that the versions in the `package-lock.json` match those in the `package.json` and are not implicitly modified from what is in version control. For more information see: https://docs.npmjs.com/cli/v8/commands/npm-ci

Fixes #13