### PR TITLE
Github Workflow Node version updates

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: ${{ matrix.node-version }}
 
       - name: Build for Node.js ${{ matrix.node-version }}
         run: |


### PR DESCRIPTION
Testing on all LTS versions in maintenance, and the current (17) to early fix any issues with the next LTS (18).

Removed 8.x, 10.x as they are deprecated. And 13.x as it is not a LTS version.